### PR TITLE
feat(skills): delegate skills IPC to Legion daemon; add DaemonChatClient

### DIFF
--- a/electron/agent/daemon-chat-client.ts
+++ b/electron/agent/daemon-chat-client.ts
@@ -6,9 +6,16 @@
  * This client is a transport layer only.
  */
 
+import { randomUUID } from 'crypto';
+import { withBrandUserAgent } from '../utils/user-agent.js';
+
 export interface DaemonChatOptions {
   baseUrl: string;
   conversationId?: string;
+  /** Optional Bearer token for daemon auth (from resolveAuthToken). */
+  authToken?: string | null;
+  /** Request timeout in milliseconds (default: 30 000). */
+  timeoutMs?: number;
 }
 
 export interface Message {
@@ -18,6 +25,7 @@ export interface Message {
 
 export interface InferenceRequest {
   messages: Message[];
+  conversation_id?: string;
   metadata?: Record<string, unknown>;
   stream?: boolean;
 }
@@ -28,13 +36,19 @@ export interface InferenceChunk {
   error?: string;
 }
 
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 export class DaemonChatClient {
   private readonly _baseUrl: string;
   private readonly _conversationId: string;
+  private readonly _authToken: string | null;
+  private readonly _timeoutMs: number;
 
   constructor(options: DaemonChatOptions) {
     this._baseUrl = options.baseUrl.replace(/\/$/, '');
-    this._conversationId = options.conversationId ?? `conv_${Math.random().toString(36).slice(2, 10)}`;
+    this._conversationId = options.conversationId ?? randomUUID();
+    this._authToken = options.authToken ?? null;
+    this._timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
   get conversationId(): string {
@@ -45,25 +59,36 @@ export class DaemonChatClient {
     return `${this._baseUrl}/api/llm/inference`;
   }
 
+  private buildHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    return withBrandUserAgent({
+      'content-type': 'application/json',
+      'accept': 'text/event-stream',
+      ...(this._authToken ? { Authorization: `Bearer ${this._authToken}` } : {}),
+      ...extra,
+    });
+  }
+
   /**
-   * Send a user message to the daemon. Streams response chunks to the callback.
+   * Send a user message to the daemon. Streams SSE response chunks to the callback.
    * Returns the full concatenated response text.
    */
   async sendMessage(
     content: string,
     onChunk: (chunk: string) => void,
-    metadata: Record<string, unknown> = {}
+    metadata: Record<string, unknown> = {},
   ): Promise<string> {
     const body: InferenceRequest = {
       messages: [{ role: 'user', content }],
-      metadata: { ...metadata, conversation_id: this._conversationId },
-      stream:   true
+      conversation_id: this._conversationId,
+      metadata,
+      stream: true,
     };
 
     const response = await fetch(this.inferenceUrl, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify(body)
+      method: 'POST',
+      headers: this.buildHeaders(),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(this._timeoutMs),
     });
 
     if (!response.ok) {
@@ -76,14 +101,40 @@ export class DaemonChatClient {
 
     const decoder = new TextDecoder();
     let fullText = '';
+    let buffer = '';
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      const chunk = decoder.decode(value, { stream: true });
-      fullText += chunk;
-      onChunk(chunk);
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          const trimmed = line.replace(/\r$/, '');
+          if (!trimmed || trimmed.startsWith(':') || trimmed.startsWith('event:')) continue;
+          if (trimmed.startsWith('data:')) {
+            const raw = trimmed.slice(5).trimStart();
+            if (!raw || raw === '[DONE]') continue;
+            try {
+              const parsed = JSON.parse(raw) as { text?: string; delta?: string; done?: boolean };
+              const delta = parsed.text ?? parsed.delta ?? '';
+              if (delta) {
+                fullText += delta;
+                onChunk(delta);
+              }
+            } catch {
+              // Non-JSON data line — forward as raw text delta
+              fullText += raw;
+              onChunk(raw);
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
     }
 
     return fullText;
@@ -93,11 +144,14 @@ export class DaemonChatClient {
    * Cancel any active skill running in this conversation.
    */
   async cancelSkill(): Promise<boolean> {
-    const url = `${this._baseUrl}/api/skills/${this._conversationId}/cancel`;
-    const response = await fetch(url, { method: 'DELETE' });
-    if (!response.ok) return false;
-
-    const data = await response.json() as { cancelled?: boolean };
-    return data.cancelled === true;
+    const url = `${this._baseUrl}/api/skills/active/${encodeURIComponent(this._conversationId)}`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: withBrandUserAgent({
+        ...(this._authToken ? { Authorization: `Bearer ${this._authToken}` } : {}),
+      }),
+      signal: AbortSignal.timeout(this._timeoutMs),
+    });
+    return response.ok;
   }
 }

--- a/electron/agent/daemon-chat-client.ts
+++ b/electron/agent/daemon-chat-client.ts
@@ -1,0 +1,103 @@
+/**
+ * DaemonChatClient — thin HTTP client that forwards LLM inference requests
+ * to the LegionIO daemon running on localhost.
+ *
+ * All skill injection, enrichment, and inference runs daemon-side.
+ * This client is a transport layer only.
+ */
+
+export interface DaemonChatOptions {
+  baseUrl: string;
+  conversationId?: string;
+}
+
+export interface Message {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export interface InferenceRequest {
+  messages: Message[];
+  metadata?: Record<string, unknown>;
+  stream?: boolean;
+}
+
+export interface InferenceChunk {
+  delta?: string;
+  done?: boolean;
+  error?: string;
+}
+
+export class DaemonChatClient {
+  private readonly _baseUrl: string;
+  private readonly _conversationId: string;
+
+  constructor(options: DaemonChatOptions) {
+    this._baseUrl = options.baseUrl.replace(/\/$/, '');
+    this._conversationId = options.conversationId ?? `conv_${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  get conversationId(): string {
+    return this._conversationId;
+  }
+
+  private get inferenceUrl(): string {
+    return `${this._baseUrl}/api/llm/inference`;
+  }
+
+  /**
+   * Send a user message to the daemon. Streams response chunks to the callback.
+   * Returns the full concatenated response text.
+   */
+  async sendMessage(
+    content: string,
+    onChunk: (chunk: string) => void,
+    metadata: Record<string, unknown> = {}
+  ): Promise<string> {
+    const body: InferenceRequest = {
+      messages: [{ role: 'user', content }],
+      metadata: { ...metadata, conversation_id: this._conversationId },
+      stream:   true
+    };
+
+    const response = await fetch(this.inferenceUrl, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Daemon inference error ${response.status}: ${err}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let fullText = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      fullText += chunk;
+      onChunk(chunk);
+    }
+
+    return fullText;
+  }
+
+  /**
+   * Cancel any active skill running in this conversation.
+   */
+  async cancelSkill(): Promise<boolean> {
+    const url = `${this._baseUrl}/api/skills/${this._conversationId}/cancel`;
+    const response = await fetch(url, { method: 'DELETE' });
+    if (!response.ok) return false;
+
+    const data = await response.json() as { cancelled?: boolean };
+    return data.cancelled === true;
+  }
+}

--- a/electron/agent/daemon-chat-client.ts
+++ b/electron/agent/daemon-chat-client.ts
@@ -102,9 +102,43 @@ export class DaemonChatClient {
     const decoder = new TextDecoder();
     let fullText = '';
     let buffer = '';
+    let streamDone = false;
+    let streamError: string | undefined;
+
+    const processLine = (line: string): void => {
+      const trimmed = line.replace(/\r$/, '');
+      if (!trimmed || trimmed.startsWith(':') || trimmed.startsWith('event:')) return;
+      if (!trimmed.startsWith('data:')) return;
+      const raw = trimmed.slice(5).trimStart();
+      if (!raw || raw === '[DONE]') {
+        streamDone = true;
+        return;
+      }
+      try {
+        const parsed = JSON.parse(raw) as { text?: string; delta?: string; done?: boolean; error?: string };
+        if (parsed.error) {
+          streamError = parsed.error;
+          streamDone = true;
+          return;
+        }
+        if (parsed.done) {
+          streamDone = true;
+          return;
+        }
+        const delta = parsed.text ?? parsed.delta ?? '';
+        if (delta) {
+          fullText += delta;
+          onChunk(delta);
+        }
+      } catch {
+        // Non-JSON data line — forward as raw text delta
+        fullText += raw;
+        onChunk(raw);
+      }
+    };
 
     try {
-      while (true) {
+      while (!streamDone) {
         const { done, value } = await reader.read();
         if (done) break;
 
@@ -113,29 +147,20 @@ export class DaemonChatClient {
         buffer = lines.pop() ?? '';
 
         for (const line of lines) {
-          const trimmed = line.replace(/\r$/, '');
-          if (!trimmed || trimmed.startsWith(':') || trimmed.startsWith('event:')) continue;
-          if (trimmed.startsWith('data:')) {
-            const raw = trimmed.slice(5).trimStart();
-            if (!raw || raw === '[DONE]') continue;
-            try {
-              const parsed = JSON.parse(raw) as { text?: string; delta?: string; done?: boolean };
-              const delta = parsed.text ?? parsed.delta ?? '';
-              if (delta) {
-                fullText += delta;
-                onChunk(delta);
-              }
-            } catch {
-              // Non-JSON data line — forward as raw text delta
-              fullText += raw;
-              onChunk(raw);
-            }
-          }
+          processLine(line);
+          if (streamDone) break;
         }
+      }
+
+      // Flush any remaining buffered data after the read loop
+      if (buffer.trim().length > 0) {
+        processLine(buffer.replace(/\r$/, ''));
       }
     } finally {
       reader.releaseLock();
     }
+
+    if (streamError) throw new Error(`Daemon stream error: ${streamError}`);
 
     return fullText;
   }

--- a/electron/ipc/skills.ts
+++ b/electron/ipc/skills.ts
@@ -5,38 +5,64 @@
  * This file exposes read-only list/describe and cancel operations only.
  */
 import type { IpcMain } from 'electron';
+import type { AppConfig } from '../config/schema.js';
+import {
+  resolveDaemonUrl,
+  authHeaders,
+  withTimeout,
+} from '../lib/daemon-client.js';
 
-const DAEMON_URL = process.env.LEGION_DAEMON_URL ?? 'http://localhost:4567';
-
-export function registerSkillsHandlers(ipcMain: IpcMain, _appHome: string): void {
+export function registerSkillsHandlers(
+  ipcMain: IpcMain,
+  appHome: string,
+  getConfig: () => AppConfig,
+): void {
   ipcMain.handle('skills:list', async () => {
-    const res = await fetch(`${DAEMON_URL}/api/skills`);
+    const config = getConfig();
+    const base = resolveDaemonUrl(config);
+    const res = await fetch(
+      new URL('/api/skills', base).toString(),
+      { headers: authHeaders(config, appHome), ...withTimeout() },
+    );
     if (!res.ok) throw new Error(`skills:list failed: ${res.status}`);
     return res.json();
   });
 
   ipcMain.handle('skills:get', async (_event, name: string) => {
+    const config = getConfig();
+    const base = resolveDaemonUrl(config);
     const [ns, nm] = name.includes(':') ? name.split(':', 2) : ['default', name];
-    const res = await fetch(`${DAEMON_URL}/api/skills/${encodeURIComponent(ns)}/${encodeURIComponent(nm)}`);
-    if (!res.ok) return { error: `Skill "${name}" not found.` };
+    const res = await fetch(
+      new URL(`/api/skills/${encodeURIComponent(ns)}/${encodeURIComponent(nm)}`, base).toString(),
+      { headers: authHeaders(config, appHome), ...withTimeout() },
+    );
+    if (!res.ok) {
+      if (res.status === 404) return { error: `Skill "${name}" not found.` };
+      const responseText = await res.text();
+      throw new Error(
+        `skills:get failed: ${res.status}${responseText ? ` - ${responseText}` : ''}`,
+      );
+    }
     return res.json();
   });
 
-  // skills:delete and skills:toggle are no longer supported; skills are managed daemon-side
+  // skills:delete and skills:toggle are no longer supported; skills are managed daemon-side.
+  // Return success: false to preserve the IPC contract shape expected by the renderer.
   ipcMain.handle('skills:delete', async (_event, _name: string) => {
-    return { error: 'Skill deletion must be performed via the Legion daemon.' };
+    return { success: false, error: 'Skill deletion must be performed via the Legion daemon.' };
   });
 
   ipcMain.handle('skills:toggle', async (_event, _name: string, _enable: boolean) => {
-    return { error: 'Skill toggling must be performed via the Legion daemon.' };
+    return { success: false, enabled: _enable, error: 'Skill toggling must be performed via the Legion daemon.' };
   });
 
   ipcMain.handle('skills:cancel', async (_event, conversationId: string) => {
+    const config = getConfig();
+    const base = resolveDaemonUrl(config);
     const res = await fetch(
-      `${DAEMON_URL}/api/skills/active/${encodeURIComponent(conversationId)}`,
-      { method: 'DELETE' }
+      new URL(`/api/skills/active/${encodeURIComponent(conversationId)}`, base).toString(),
+      { method: 'DELETE', headers: authHeaders(config, appHome), ...withTimeout() },
     );
-    if (!res.ok) throw new Error(`skills:cancel failed: ${res.status}`);
-    return res.json();
+    return res.ok;
   });
 }

--- a/electron/ipc/skills.ts
+++ b/electron/ipc/skills.ts
@@ -1,85 +1,42 @@
+/**
+ * skills IPC handlers — delegates all skill operations to the Legion daemon.
+ *
+ * All skill execution, registration, and state management is now daemon-side.
+ * This file exposes read-only list/describe and cancel operations only.
+ */
 import type { IpcMain } from 'electron';
-import { readFileSync, existsSync, readdirSync, rmSync } from 'fs';
-import { join } from 'path';
-import type { AppConfig } from '../config/schema.js';
-import { loadSkillsFromDisk } from '../tools/skill-loader.js';
-import { readEffectiveConfig, writeDesktopConfig } from './config.js';
 
-function readConfig(appHome: string): AppConfig {
-  return readEffectiveConfig(appHome);
-}
+const DAEMON_URL = process.env.LEGION_DAEMON_URL ?? 'http://localhost:4567';
 
-export function registerSkillsHandlers(ipcMain: IpcMain, appHome: string): void {
+export function registerSkillsHandlers(ipcMain: IpcMain, _appHome: string): void {
   ipcMain.handle('skills:list', async () => {
-    const config = readConfig(appHome);
-    const skillsDir = config.skills?.directory || join(appHome, 'skills');
-    const skills = loadSkillsFromDisk(skillsDir);
-    const enabled = config.skills?.enabled ?? [];
-
-    return skills.map(({ manifest, dir }) => ({
-      name: manifest.name,
-      description: manifest.description,
-      version: manifest.version,
-      type: manifest.execution.type,
-      enabled: enabled.length === 0 || enabled.includes(manifest.name),
-      dir,
-    }));
+    const res = await fetch(`${DAEMON_URL}/api/skills`);
+    if (!res.ok) throw new Error(`skills:list failed: ${res.status}`);
+    return res.json();
   });
 
   ipcMain.handle('skills:get', async (_event, name: string) => {
-    const config = readConfig(appHome);
-    const skillsDir = config.skills?.directory || join(appHome, 'skills');
-    const skillDir = join(skillsDir, name);
-    const manifestPath = join(skillDir, 'skill.json');
-
-    if (!existsSync(manifestPath)) return { error: `Skill "${name}" not found.` };
-
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
-    const files: Record<string, string> = {};
-
-    try {
-      const entries = readdirSync(skillDir);
-      for (const entry of entries) {
-        if (entry === 'skill.json') continue;
-        try {
-          files[entry] = readFileSync(join(skillDir, entry), 'utf-8');
-        } catch { /* skip binary files */ }
-      }
-    } catch { /* ignore */ }
-
-    return { manifest, files, dir: skillDir };
+    const [ns, nm] = name.includes(':') ? name.split(':', 2) : ['default', name];
+    const res = await fetch(`${DAEMON_URL}/api/skills/${encodeURIComponent(ns)}/${encodeURIComponent(nm)}`);
+    if (!res.ok) return { error: `Skill "${name}" not found.` };
+    return res.json();
   });
 
-  ipcMain.handle('skills:delete', async (_event, name: string) => {
-    const config = readConfig(appHome);
-    const skillsDir = config.skills?.directory || join(appHome, 'skills');
-    const skillDir = join(skillsDir, name);
-
-    if (!existsSync(skillDir)) return { error: `Skill "${name}" not found.` };
-
-    rmSync(skillDir, { recursive: true, force: true });
-
-    // Remove from enabled list
-    const enabled = (config.skills?.enabled ?? []).filter((s: string) => s !== name);
-    config.skills = { ...config.skills, enabled, directory: config.skills?.directory ?? join(appHome, 'skills') };
-    writeDesktopConfig(appHome, config);
-
-    return { success: true };
+  // skills:delete and skills:toggle are no longer supported; skills are managed daemon-side
+  ipcMain.handle('skills:delete', async (_event, _name: string) => {
+    return { error: 'Skill deletion must be performed via the Legion daemon.' };
   });
 
-  ipcMain.handle('skills:toggle', async (_event, name: string, enable: boolean) => {
-    const config = readConfig(appHome);
-    let enabled = [...(config.skills?.enabled ?? [])];
+  ipcMain.handle('skills:toggle', async (_event, _name: string, _enable: boolean) => {
+    return { error: 'Skill toggling must be performed via the Legion daemon.' };
+  });
 
-    if (enable && !enabled.includes(name)) {
-      enabled.push(name);
-    } else if (!enable) {
-      enabled = enabled.filter((s: string) => s !== name);
-    }
-
-    config.skills = { ...config.skills, enabled, directory: config.skills?.directory ?? join(appHome, 'skills') };
-    writeDesktopConfig(appHome, config);
-
-    return { success: true, enabled: enable };
+  ipcMain.handle('skills:cancel', async (_event, conversationId: string) => {
+    const res = await fetch(
+      `${DAEMON_URL}/api/skills/active/${encodeURIComponent(conversationId)}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) throw new Error(`skills:cancel failed: ${res.status}`);
+    return res.json();
   });
 }

--- a/electron/ipc/skills.ts
+++ b/electron/ipc/skills.ts
@@ -24,7 +24,12 @@ export function registerSkillsHandlers(
       new URL('/api/skills', base).toString(),
       { headers: authHeaders(config, appHome), ...withTimeout() },
     );
-    if (!res.ok) throw new Error(`skills:list failed: ${res.status}`);
+    if (!res.ok) {
+      const responseText = await res.text();
+      throw new Error(
+        `skills:list failed: ${res.status}${responseText ? ` - ${responseText}` : ''}`,
+      );
+    }
     return res.json();
   });
 
@@ -59,10 +64,14 @@ export function registerSkillsHandlers(
   ipcMain.handle('skills:cancel', async (_event, conversationId: string) => {
     const config = getConfig();
     const base = resolveDaemonUrl(config);
-    const res = await fetch(
-      new URL(`/api/skills/active/${encodeURIComponent(conversationId)}`, base).toString(),
-      { method: 'DELETE', headers: authHeaders(config, appHome), ...withTimeout() },
-    );
-    return res.ok;
+    try {
+      const res = await fetch(
+        new URL(`/api/skills/active/${encodeURIComponent(conversationId)}`, base).toString(),
+        { method: 'DELETE', headers: authHeaders(config, appHome), ...withTimeout() },
+      );
+      return res.ok;
+    } catch {
+      return false;
+    }
   });
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -432,7 +432,7 @@ if (gotSingleInstanceLock) {
     registerConversationHandlers(ipcMain, APP_HOME, getConfig);
     registerMcpHandlers(ipcMain);
     registerMemoryHandlers(ipcMain, APP_HOME, getConfig);
-    registerSkillsHandlers(ipcMain, APP_HOME);
+    registerSkillsHandlers(ipcMain, APP_HOME, getConfig);
     registerDaemonSettingsHandlers(ipcMain, APP_HOME, getConfig);
     registerDaemonApiHandlers(
       ipcMain,


### PR DESCRIPTION
## Summary

- Replaces local YAML-based skill discovery in `electron/ipc/skills.ts` with thin HTTP delegation to the Legion daemon
- `skills:list` — `GET /api/skills` on the daemon; `skills:get` — `GET /api/skills/:name`
- `skills:cancel` — `DELETE /api/skills/active/:conversationId` on the daemon
- `skills:delete` and `skills:toggle` remain as stubs returning informative error messages (preload expects these handlers; daemon manages lifecycle)
- New `electron/agent/daemon-chat-client.ts` — `DaemonChatClient` class: thin HTTP transport for LLM inference streaming and skill cancel; used by chat panels talking to the Legion daemon

## Test plan

- [ ] `skills:list` IPC call returns skills array from daemon `GET /api/skills`
- [ ] `skills:cancel` IPC call sends `DELETE /api/skills/active/:id` to daemon and returns `true`/`false`
- [ ] `skills:delete` and `skills:toggle` return `{ error: "..." }` without hanging
- [ ] `DaemonChatClient.sendMessage` streams chunks via `onChunk` callback and returns full content string
- [ ] `DaemonChatClient.cancelSkill` sends DELETE and returns boolean

🤖 Generated with [Claude Code](https://claude.com/claude-code)