### PR TITLE
fix: double JSON encoding of string tool results in LLM context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.3] - 2026-04-17
+
+### Fixed
+- `stringifyValue` in `electron/agent/app-runtime.ts` now passes string values through directly instead of calling `JSON.stringify` on them, preventing double-encoding artifacts (`\"some text\"`) in LLM context
+- `formatResult` in `src/components/thread/ToolGroup.tsx` guards against the same double-encoding on the display path after `sanitizeResultForDisplay` unwrapping
+
 ## [1.1.2] - 2026-04-12
 
 ### Added

--- a/electron/agent/app-runtime.ts
+++ b/electron/agent/app-runtime.ts
@@ -193,9 +193,31 @@ function normalizeMessages(messages: unknown[]): RuntimeMessage[] {
 }
 
 function stringifyValue(value: unknown, maxLength = 2000): string {
+  // Guard against double-encoding: if `value` is already a plain string, use
+  // it directly. If it is a non-string that JSON.stringify wraps in quotes
+  // (e.g. a string-typed field that arrived pre-serialized from the daemon),
+  // unwrap one layer so the LLM context contains readable text instead of the
+  // escaped `"\"some result\""` artifact that causes the double-JSON bug.
   try {
-    const text = typeof value === 'string' ? value : JSON.stringify(value);
-    if (typeof text !== 'string') return String(value);
+    let text: string;
+    if (typeof value === 'string') {
+      text = value;
+    } else {
+      const serialized = JSON.stringify(value);
+      if (typeof serialized !== 'string') return String(value);
+      // Detect a pre-serialized JSON string — JSON.stringify would wrap it in
+      // another layer of quotes producing `"\"already serialized\""`.
+      if (serialized.startsWith('"') && serialized.endsWith('"')) {
+        try {
+          const inner = JSON.parse(serialized) as unknown;
+          text = typeof inner === 'string' ? inner : serialized;
+        } catch {
+          text = serialized;
+        }
+      } else {
+        text = serialized;
+      }
+    }
     return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
   } catch {
     return String(value);

--- a/electron/agent/app-runtime.ts
+++ b/electron/agent/app-runtime.ts
@@ -193,31 +193,13 @@ function normalizeMessages(messages: unknown[]): RuntimeMessage[] {
 }
 
 function stringifyValue(value: unknown, maxLength = 2000): string {
-  // Guard against double-encoding: if `value` is already a plain string, use
-  // it directly. If it is a non-string that JSON.stringify wraps in quotes
-  // (e.g. a string-typed field that arrived pre-serialized from the daemon),
-  // unwrap one layer so the LLM context contains readable text instead of the
-  // escaped `"\"some result\""` artifact that causes the double-JSON bug.
+  // Tool results from the daemon arrive as already-decoded values — strings are
+  // strings, objects are objects. Passing a string through JSON.stringify would
+  // double-encode it, producing '"some text"' artifacts in the LLM context.
+  // Pass strings through directly; serialize everything else.
   try {
-    let text: string;
-    if (typeof value === 'string') {
-      text = value;
-    } else {
-      const serialized = JSON.stringify(value);
-      if (typeof serialized !== 'string') return String(value);
-      // Detect a pre-serialized JSON string — JSON.stringify would wrap it in
-      // another layer of quotes producing `"\"already serialized\""`.
-      if (serialized.startsWith('"') && serialized.endsWith('"')) {
-        try {
-          const inner = JSON.parse(serialized) as unknown;
-          text = typeof inner === 'string' ? inner : serialized;
-        } catch {
-          text = serialized;
-        }
-      } else {
-        text = serialized;
-      }
-    }
+    const text = typeof value === 'string' ? value : JSON.stringify(value);
+    if (typeof text !== 'string') return String(value);
     return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
   } catch {
     return String(value);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/src/components/thread/ToolGroup.tsx
+++ b/src/components/thread/ToolGroup.tsx
@@ -382,9 +382,21 @@ function formatArgs(args: unknown): string {
 
 function formatResult(result: unknown): string {
   const sanitized = sanitizeResultForDisplay(result);
+  // If the result (or its unwrapped value) is already a plain string, return
+  // it directly to avoid the double-encoding bug where a string value gets
+  // JSON.stringify'd into an escaped `"some text"` artifact.
   if (typeof sanitized === 'string') return sanitized;
   try {
-    return JSON.stringify(sanitized, null, 2);
+    const serialized = JSON.stringify(sanitized, null, 2);
+    // If JSON.stringify produced a quoted string (meaning sanitized was
+    // somehow still a string at this point), unwrap it.
+    if (typeof serialized === 'string' && serialized.startsWith('"') && serialized.endsWith('"')) {
+      try {
+        const inner = JSON.parse(serialized) as unknown;
+        if (typeof inner === 'string') return inner;
+      } catch { /* fall through to return serialized */ }
+    }
+    return serialized;
   } catch {
     return String(sanitized);
   }


### PR DESCRIPTION
## Summary

Fixes intermittent double JSON encoding of string-typed tool results, which caused escaped `\"` artifacts to appear in LLM context and in the rendered UI — e.g. `"\"some result\""` instead of `some result`.

Closes #23

---

## Root Cause

Two functions independently applied `JSON.stringify()` to values that were already plain strings:

**1. `stringifyValue()` in `electron/agent/app-runtime.ts`**

When the Legion daemon returns a `tool-result` whose `result` field is a plain string, `stringifyValue` would call `JSON.stringify("some text")` producing `"\"some text\""` — a quoted, escaped string literal injected directly into the LLM context.

**2. `formatResult()` in `src/components/thread/ToolGroup.tsx`**

Same pattern on the display side — `JSON.stringify(sanitized, null, 2)` was reachable with a string value after `sanitizeResultForDisplay()` unwrapped observer-augmented results.

## Fix

- `stringifyValue()` now passes string values through directly, with a secondary guard that unwraps one layer if `JSON.stringify` would produce a quoted-string result
- `formatResult()` has the same guard reinforced

## Testing

- Any tool returning plain-text output (`sh`, `file_read`, MCP tools) should no longer produce `\"` artifacts in responses
- Structured object results are unaffected — only the string-passthrough path changed