### PR TITLE
feat: fetch model catalog from daemon instead of local config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.6] - 2026-04-22
+
+### Changed
+- Model catalog now fetched from daemon `/v1/models` endpoint instead of requiring manual config in `~/.legionio/config.json`; discovers all models the daemon has valid credentials for at runtime
+- Falls back to `/api/llm/providers` (default model per provider) when `/v1/models` is unavailable, then to local config catalog if daemon is unreachable
+- Exposed `daemon:llm-models` IPC handler for direct `/v1/models` access from renderer
+
 ## [1.1.5] - 2026-04-21
 
 ### Fixed

--- a/electron/ipc/agent.ts
+++ b/electron/ipc/agent.ts
@@ -7,10 +7,70 @@ import type { StreamEvent, ReasoningEffort } from '../agent/mastra-agent.js';
 import { getAppStatus, resolveAgentBackend, streamAppAgent } from '../agent/app-runtime.js';
 import type { AppConfig } from '../config/schema.js';
 import { readEffectiveConfig } from './config.js';
-// Compaction removed — the daemon handles its own context management
+import { daemonGet } from '../lib/daemon-client.js';
 import type { ToolDefinition } from '../tools/types.js';
 import { ensureSafeToolDefinitions } from '../tools/naming.js';
 import { sendSubAgentFollowUp, stopSubAgent, getActiveSubAgentIds } from '../tools/sub-agent.js';
+
+type DaemonModelEntry = {
+  key: string;
+  displayName: string;
+  maxInputTokens?: number;
+  computerUseSupport?: string;
+  visionCapable?: boolean;
+  preferredTarget?: string;
+};
+
+type DaemonModelCatalog = {
+  models: DaemonModelEntry[];
+  defaultKey: string | null;
+};
+
+type OpenAIModelObject = { id: string; owned_by?: string };
+type ProvidersResponse = {
+  providers?: Array<{ name: string; default_model?: string }>;
+};
+
+async function fetchDaemonModels(
+  config: AppConfig,
+  appHome: string,
+): Promise<DaemonModelCatalog | null> {
+  const modelsResult = await daemonGet<OpenAIModelObject[] | { data?: OpenAIModelObject[] }>(
+    config, appHome, '/v1/models',
+  );
+
+  let modelList: OpenAIModelObject[] = [];
+  if (modelsResult.ok && modelsResult.data) {
+    const raw = modelsResult.data;
+    modelList = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw.data) ? raw.data : [];
+  }
+
+  if (modelList.length === 0) {
+    const providersResult = await daemonGet<ProvidersResponse>(config, appHome, '/api/llm/providers');
+    if (providersResult.ok && providersResult.data) {
+      const providers = providersResult.data.providers ?? [];
+      modelList = providers
+        .filter((p) => p.default_model)
+        .map((p) => ({ id: p.default_model!, owned_by: p.name }));
+    }
+  }
+
+  if (modelList.length === 0) return null;
+
+  const models: DaemonModelEntry[] = modelList.map((m) => ({
+    key: m.id,
+    displayName: m.id,
+  }));
+
+  const configDefault = config.models?.defaultModelKey;
+  const defaultKey = configDefault && models.some((m) => m.key === configDefault)
+    ? configDefault
+    : models[0]?.key ?? null;
+
+  return { models, defaultKey };
+}
 
 const activeStreams = new Map<string, { abort: () => void }>();
 const activeObserverSessions = new Map<string, string>();
@@ -317,13 +377,16 @@ export function registerAgentHandlers(ipcMain: IpcMain, appHome: string): void {
     return { ids: getActiveSubAgentIds() };
   });
 
-  // Model catalog endpoint
-  ipcMain.handle('agent:model-catalog', () => {
+  // Model catalog endpoint — fetches available models from the daemon
+  ipcMain.handle('agent:model-catalog', async () => {
     try {
       const config = readEffectiveConfig(appHome);
+      const daemonModels = await fetchDaemonModels(config, appHome);
+      if (daemonModels) return daemonModels;
+
       const catalog = resolveModelCatalog(config);
       return {
-        models: catalog.entries.map((e: { key: string; displayName: string; modelConfig: { maxInputTokens?: number }; computerUseSupport?: string; visionCapable?: boolean; preferredTarget?: string }) => ({
+        models: catalog.entries.map((e) => ({
           key: e.key,
           displayName: e.displayName,
           maxInputTokens: e.modelConfig.maxInputTokens,

--- a/electron/ipc/daemon-api.ts
+++ b/electron/ipc/daemon-api.ts
@@ -428,6 +428,10 @@ export function registerDaemonApiHandlers(
   ipcMain.handle('daemon:llm-token-budget-reset', async () =>
     daemonPost(cfg(), appHome, '/api/llm/token_budget/reset', {}));
 
+  // ── LLM Models (OpenAI-compat /v1/models) ──
+  ipcMain.handle('daemon:llm-models', async () =>
+    daemonGet(cfg(), appHome, '/v1/models'));
+
   // ── Native Dispatch (legion-llm v0.6.0) ──
   ipcMain.handle('daemon:llm-providers', async () =>
     daemonGet(cfg(), appHome, '/api/llm/providers'));

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -156,6 +156,7 @@ const appAPI = {
     absorberResolve: (input: string) => ipcRenderer.invoke('daemon:absorber-resolve', input),
     absorberDispatch: (input: string, scope?: string) => ipcRenderer.invoke('daemon:absorber-dispatch', input, scope),
     absorberJob: (jobId: string) => ipcRenderer.invoke('daemon:absorber-job', jobId),
+    llmModels: () => ipcRenderer.invoke('daemon:llm-models'),
     health: () => ipcRenderer.invoke('daemon:health'),
     ready: () => ipcRenderer.invoke('daemon:ready'),
     metrics: () => ipcRenderer.invoke('daemon:metrics'),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/src/lib/ipc-client.ts
+++ b/src/lib/ipc-client.ts
@@ -127,6 +127,7 @@ type AppAPI = {
     absorberResolve: (input: string) => Promise<DaemonResult>;
     absorberDispatch: (input: string, scope?: string) => Promise<DaemonResult>;
     absorberJob: (jobId: string) => Promise<DaemonResult>;
+    llmModels: () => Promise<DaemonResult>;
     health: () => Promise<DaemonResult>;
     ready: () => Promise<DaemonResult>;
     metrics: () => Promise<DaemonResult>;


### PR DESCRIPTION
## Summary
- Model selector dropdown now queries the daemon's `/v1/models` endpoint to discover available models at runtime
- Falls back to `/api/llm/providers` (default model per provider), then to the local `config.json` catalog if the daemon is unreachable
- No more manually configuring every model in `~/.legionio/config.json` — the daemon already knows what providers have valid credentials and what Ollama models are pulled

## Changes
- **`electron/ipc/agent.ts`** — `agent:model-catalog` handler now calls `fetchDaemonModels()` first; local config catalog is the fallback
- **`electron/ipc/daemon-api.ts`** — added `daemon:llm-models` IPC handler (`GET /v1/models`)
- **`electron/preload.ts`** — exposed `daemon.llmModels` in the IPC bridge
- **`src/lib/ipc-client.ts`** — added `llmModels` to the daemon type definition

## How it works
1. `agent:model-catalog` calls daemon `GET /v1/models` (OpenAI-compat format)
2. `daemonGet` extracts `body.data` → array of `{ id, owned_by }` model objects
3. Maps to `{ key: id, displayName: id }` entries for the `ModelSelector` dropdown
4. If `/v1/models` returns empty (auth issue, no models), falls back to `GET /api/llm/providers` and uses each provider's `default_model`
5. If daemon is unreachable, falls back to the existing local `resolveModelCatalog(config)` path
6. `defaultKey` respects `config.models.defaultModelKey` when it matches a daemon model, otherwise picks the first available

## Test plan
- [ ] Start daemon with Ollama + at least one cloud provider configured
- [ ] Open Interlink → model selector should show all daemon-discovered models without any manual config
- [ ] Stop daemon → model selector should fall back to local config catalog
- [ ] Verify model selection persists across conversation switches