### PR TITLE
feat: daemon model catalog + forward manual model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.7] - 2026-04-24
+
+### Fixed
+- Manual model selection from dropdown now forwards the chosen model to the daemon; previously only static `runtime.daemon.model` overrides were sent, so selecting a different model in the UI had no effect
+- Daemon-sourced models (from `/v1/models`) now pass their model key through the passthrough config instead of sending an empty string
+- Added `mapProviderForDaemon()` to translate Interlink provider types (`amazon-bedrock`, `google`, `openai-compatible`) to daemon-side names (`bedrock`, `gemini`, auto-detect)
+
 ## [1.1.6] - 2026-04-22
 
 ### Changed

--- a/electron/agent/app-runtime.ts
+++ b/electron/agent/app-runtime.ts
@@ -2,7 +2,7 @@ import { existsSync, realpathSync } from 'fs';
 import { join, resolve } from 'path';
 import type { AppConfig } from '../config/schema.js';
 import { resolveDaemonUrl, resolveAuthToken } from '../lib/daemon-client.js';
-import type { LLMModelConfig } from './model-catalog.js';
+import type { LLMModelConfig, LLMProviderType } from './model-catalog.js';
 import type { StreamEvent } from './mastra-agent.js';
 import { withBrandUserAgent } from '../utils/user-agent.js';
 
@@ -145,6 +145,16 @@ function rubyPathCandidates(): string[] {
   ].filter(Boolean);
 }
 
+function mapProviderForDaemon(provider: LLMProviderType | string | undefined): string | undefined {
+  if (!provider) return undefined;
+  switch (provider) {
+    case 'amazon-bedrock': return 'bedrock';
+    case 'openai-compatible': return undefined;
+    case 'google': return 'gemini';
+    default: return provider;
+  }
+}
+
 function extractText(content: unknown): string {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
@@ -268,15 +278,23 @@ async function* streamDaemonApp(options: StreamAppOptions): AsyncGenerator<Strea
     return;
   }
 
-  // Let the daemon use its own model/provider defaults.
-  // Only forward model/provider if explicitly configured for daemon override.
+  // Resolve model and provider to send to the daemon.
+  // Priority: user-selected model from dropdown → daemon config override → daemon defaults.
   const daemonRuntime = options.config.runtime?.daemon as Record<string, unknown> | undefined;
   const daemonModelOverride = daemonRuntime?.model as string | undefined;
   const daemonProviderOverride = daemonRuntime?.provider as string | undefined;
+
+  const selectedModel = options.modelConfig.modelName || undefined;
+  const selectedProvider = options.modelConfig.provider || undefined;
+  const isPassthrough = !selectedModel || options.modelConfig.modelName === '';
+
+  const effectiveModel = isPassthrough ? daemonModelOverride : selectedModel;
+  const effectiveProvider = isPassthrough ? daemonProviderOverride : mapProviderForDaemon(selectedProvider);
+
   const requestBody: Record<string, unknown> = {
     messages: normalizedMessages,
-    ...(daemonModelOverride ? { model: daemonModelOverride } : {}),
-    ...(daemonProviderOverride ? { provider: daemonProviderOverride } : {}),
+    ...(effectiveModel ? { model: effectiveModel } : {}),
+    ...(effectiveProvider ? { provider: effectiveProvider } : {}),
     ...(options.tools?.length ? { tools: options.tools } : {}),
     ...(options.cwd ? { cwd: options.cwd } : {}),
     ...(options.conversationId ? { conversation_id: options.conversationId } : {}),

--- a/electron/ipc/agent.ts
+++ b/electron/ipc/agent.ts
@@ -201,19 +201,20 @@ export function registerAgentHandlers(ipcMain: IpcMain, appHome: string): void {
 
     if (!modelEntry || !streamConfig) {
       if (backend === 'legion-daemon') {
-        // Daemon manages its own models — create a passthrough config so the request proceeds
+        // Daemon manages its own models — create a passthrough config.
+        // Forward the user-selected model key so the daemon routes correctly.
         const fallbackModelConfig: LLMModelConfig = {
           provider: 'openai-compatible',
           endpoint: '',
           apiKey: '',
-          modelName: '',
+          modelName: modelKey ?? '',
           temperature: config.advanced.temperature,
           maxSteps: config.advanced.maxSteps,
           maxRetries: config.advanced.maxRetries,
         };
         const fallbackEntry: ModelCatalogEntry = {
-          key: '__daemon_default__',
-          displayName: 'Daemon Default',
+          key: modelKey ?? '__daemon_default__',
+          displayName: modelKey ?? 'Daemon Default',
           modelConfig: fallbackModelConfig,
         };
         modelEntry = fallbackEntry;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Model catalog is now fetched from the daemon's `/v1/models` endpoint at runtime instead of requiring manual config in `~/.legionio/config.json`; falls back to `/api/llm/providers` then local config if unavailable
- Manual model selection from the dropdown now forwards the chosen model to the daemon inference endpoint; previously only static `runtime.daemon` overrides were sent, so switching models in the UI had no effect
- Added `mapProviderForDaemon()` to translate Interlink provider types (`amazon-bedrock` → `bedrock`, `google` → `gemini`, `openai-compatible` → auto-detect)

## Test plan
- [ ] Start daemon, open Interlink — verify dropdown populates from daemon models
- [ ] Select a non-default model (e.g. Qwen3.6-27b), send a message in Manual mode — verify daemon logs show the selected model in the request
- [ ] Select a Bedrock model (us.anthropic.*) — verify it routes to bedrock provider
- [ ] Select Claude-Sonnet-4-6 (direct Anthropic) — verify it routes to anthropic provider
- [ ] With no daemon running, verify fallback to local config catalog still works