### PR TITLE
Fix dashboard and settings daemon shape regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.14] - 2026-04-27
+
+### Fixed
+- Mission Control worker health now reads daemon `lifecycle_state` before falling back to `status`, and counts paused workers as degraded instead of healthy (#54)
+
 ## [1.1.13] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.8] - 2026-04-27
+
+### Fixed
+- GAIA settings sessions card now reads `sessions_detail` before falling back to the legacy object-shaped `sessions`, so daemon responses with numeric `sessions` no longer render an empty value (#60)
+
 ## [1.1.7] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.13] - 2026-04-27
+
+### Fixed
+- Daemon settings GAIA card now derives mode from enabled/connected state and reads session TTL from `gaia.session.ttl` before the legacy flat fallback (#55)
+
 ## [1.1.12] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.10] - 2026-04-27
+
+### Fixed
+- Skills settings tab now unwraps daemon `{ data, meta }` envelopes and guards against non-array skill responses so the panel no longer crashes on load (#58)
+
 ## [1.1.9] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.11] - 2026-04-27
+
+### Fixed
+- Mesh settings tab now checks loaded extensions and daemon mesh flags so it can distinguish missing `lex-mesh`, solo-node operation, and real disconnected states (#57)
+
 ## [1.1.10] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.9] - 2026-04-27
+
+### Fixed
+- Events settings tab now renders daemon event names from either `type` or `event` and builds useful detail text from flat event metadata when no nested `data` payload is present (#61)
+
 ## [1.1.8] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.12] - 2026-04-27
+
+### Fixed
+- Chat responses now show a visible streaming/done/interrupted/error status pill and stale streams are recovered after 60 seconds without progress instead of leaving conversations marked running forever (#56)
+
 ## [1.1.11] - 2026-04-27
 
 ### Fixed

--- a/electron/ipc/skills.ts
+++ b/electron/ipc/skills.ts
@@ -12,6 +12,14 @@ import {
   withTimeout,
 } from '../lib/daemon-client.js';
 
+function unwrapSkillList(body: unknown): unknown[] {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === 'object' && Array.isArray((body as { data?: unknown }).data)) {
+    return (body as { data: unknown[] }).data;
+  }
+  return [];
+}
+
 export function registerSkillsHandlers(
   ipcMain: IpcMain,
   appHome: string,
@@ -30,7 +38,7 @@ export function registerSkillsHandlers(
         `skills:list failed: ${res.status}${responseText ? ` - ${responseText}` : ''}`,
       );
     }
-    return res.json();
+    return unwrapSkillList(await res.json());
   });
 
   ipcMain.handle('skills:get', async (_event, name: string) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -90,6 +90,11 @@ function fmtAgo(iso: string): string {
   return `${Math.floor(ms / 86400_000)}d`;
 }
 
+function workerState(worker: Record<string, unknown>): string {
+  const state = worker.lifecycle_state ?? worker.status;
+  return typeof state === 'string' ? state : '';
+}
+
 export const DashboardPanel: FC<{ onClose: () => void }> = () => {
   const { notifications } = useNotifications();
   const [loading, setLoading] = useState(true);
@@ -140,8 +145,8 @@ export const DashboardPanel: FC<{ onClose: () => void }> = () => {
         const arr = Array.isArray(wRes.data) ? wRes.data as Record<string, unknown>[] : [];
         setWorkers({
           total: arr.length,
-          healthy: arr.filter((w) => w.status === 'healthy' || w.status === 'active' || w.status === 'running').length,
-          degraded: arr.filter((w) => w.status === 'degraded' || w.status === 'unhealthy').length,
+          healthy: arr.filter((w) => ['healthy', 'active', 'running'].includes(workerState(w))).length,
+          degraded: arr.filter((w) => ['degraded', 'unhealthy', 'paused'].includes(workerState(w))).length,
         });
       }
 

--- a/src/components/settings/DaemonEvents.tsx
+++ b/src/components/settings/DaemonEvents.tsx
@@ -7,8 +7,13 @@ type LoadState = 'idle' | 'loading' | 'loaded' | 'error';
 
 interface DaemonEvent {
   timestamp: string;
-  type: string;
+  type?: string;
+  event?: string;
   data?: unknown;
+  task_id?: string | null;
+  runner_class?: string | null;
+  function?: string | null;
+  status?: string | null;
 }
 
 const LIVE_INTERVAL_MS = 3000;
@@ -33,8 +38,8 @@ export const DaemonEvents: FC<SettingsProps> = () => {
         const incoming = result.data as DaemonEvent[];
         if (append) {
           setEvents((prev) => {
-            const existingTs = new Set(prev.map((e) => `${e.timestamp}|${e.type}`));
-            const novel = incoming.filter((e) => !existingTs.has(`${e.timestamp}|${e.type}`));
+            const existingTs = new Set(prev.map((e) => eventKey(e)));
+            const novel = incoming.filter((e) => !existingTs.has(eventKey(e)));
             if (novel.length === 0) return prev;
             const merged = [...prev, ...novel];
             return merged.length > MAX_EVENTS ? merged.slice(merged.length - MAX_EVENTS) : merged;
@@ -106,6 +111,27 @@ export const DaemonEvents: FC<SettingsProps> = () => {
     if (data === undefined || data === null) return '';
     const str = JSON.stringify(data);
     return str.length > 120 ? str.slice(0, 120) + '…' : str;
+  };
+
+  const eventName = (evt: DaemonEvent): string => evt.type || evt.event || 'unknown';
+
+  const eventKey = (evt: DaemonEvent): string => `${evt.timestamp}|${eventName(evt)}`;
+
+  const runnerName = (runnerClass: string | null | undefined): string | null => {
+    if (!runnerClass) return null;
+    return runnerClass.replace(/^Legion::Extensions::/, '');
+  };
+
+  const detailPreview = (evt: DaemonEvent): string => {
+    const explicitData = dataPreview(evt.data);
+    if (explicitData) return explicitData;
+
+    return [
+      runnerName(evt.runner_class),
+      evt.function ? `function=${evt.function}` : null,
+      evt.task_id ? `task=${evt.task_id}` : null,
+      evt.status ? `status=${evt.status}` : null,
+    ].filter(Boolean).join(' · ');
   };
 
   if (loadState === 'idle' || loadState === 'loading') {
@@ -209,11 +235,11 @@ export const DaemonEvents: FC<SettingsProps> = () => {
                 })}
               </span>
               <span className="shrink-0 text-[10px] font-semibold font-mono w-[160px] truncate">
-                {evt.type}
+                {eventName(evt)}
               </span>
-              {evt.data !== undefined && (
+              {detailPreview(evt) && (
                 <span className="text-[10px] font-mono text-muted-foreground truncate">
-                  {dataPreview(evt.data)}
+                  {detailPreview(evt)}
                 </span>
               )}
             </div>

--- a/src/components/settings/DaemonGaia.tsx
+++ b/src/components/settings/DaemonGaia.tsx
@@ -20,10 +20,17 @@ interface GaiaStatus {
   phases?: PhaseState[];
   sensory_buffer?: { depth?: number; recent_signals?: number; max_capacity?: number };
   channels?: Array<{ name: string; type?: string; connected?: boolean }>;
-  sessions?: { active_count?: number; ttl?: number; identities?: string[] };
+  sessions?: number | SessionDetail;
+  sessions_detail?: SessionDetail;
   notification_gate?: { schedule?: boolean; presence?: string; behavioral?: number };
   dream_cycle?: { active?: boolean; last_run?: string; phase_progress?: string; insight_count?: number };
   uptime_seconds?: number;
+}
+
+interface SessionDetail {
+  active_count?: number;
+  ttl?: number;
+  identities?: string[];
 }
 
 interface TickEvent {
@@ -46,6 +53,11 @@ function formatSecondsAgo(date: Date): string {
   const mins = Math.floor(secs / 60);
   if (mins < 60) return `${mins}m ago`;
   return `${Math.floor(mins / 60)}h ago`;
+}
+
+function sessionDetailFrom(status: GaiaStatus | null): SessionDetail | undefined {
+  if (status?.sessions_detail) return status.sessions_detail;
+  return typeof status?.sessions === 'object' ? status.sessions : undefined;
 }
 
 export const DaemonGaia: FC<SettingsProps> = () => {
@@ -110,7 +122,7 @@ export const DaemonGaia: FC<SettingsProps> = () => {
   const buf = status?.sensory_buffer;
   const gate = status?.notification_gate;
   const dream = status?.dream_cycle;
-  const sessions = status?.sessions;
+  const sessions = sessionDetailFrom(status);
 
   return (
     <div className="space-y-6">

--- a/src/components/settings/DaemonMesh.tsx
+++ b/src/components/settings/DaemonMesh.tsx
@@ -16,14 +16,27 @@ interface MeshPeer {
 }
 
 interface MeshStatus {
-  node_id: string;
+  node_id?: string;
   cluster_name?: string;
   role?: string;
-  peer_count: number;
-  connected: boolean;
+  peer_count?: number;
+  total?: number;
+  online?: number;
+  connected?: boolean;
+  extension_loaded?: boolean;
+  broker_connected?: boolean;
   uptime_seconds?: number;
   gossip_interval_ms?: number;
 }
+
+interface ExtensionInfo {
+  id?: string;
+  name?: string;
+  namespace?: string;
+  state?: string;
+}
+
+type MeshState = 'not-installed' | 'connected' | 'solo' | 'disconnected';
 
 const STATUS_COLORS: Record<string, string> = {
   healthy: 'text-emerald-400',
@@ -46,6 +59,59 @@ function fmtAgo(iso: string): string {
   if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
   if (ms < 3600_000) return `${Math.floor(ms / 60_000)}m ago`;
   return `${Math.floor(ms / 3600_000)}h ago`;
+}
+
+function normalizeList<T>(value: unknown, key: string): T[] {
+  if (Array.isArray(value)) return value as T[];
+  if (value && typeof value === 'object' && Array.isArray((value as Record<string, unknown>)[key])) {
+    return (value as Record<string, unknown>)[key] as T[];
+  }
+  return [];
+}
+
+function extensionKey(extension: ExtensionInfo): string {
+  return [
+    extension.id,
+    extension.name,
+    extension.namespace ? `${extension.namespace}-${extension.name || ''}` : undefined,
+    extension.namespace ? `${extension.namespace}:${extension.name || ''}` : undefined,
+  ].filter(Boolean).join('|').toLowerCase();
+}
+
+function isMeshExtensionLoaded(extensions: ExtensionInfo[]): boolean {
+  return extensions.some((extension) => {
+    const key = extensionKey(extension);
+    return key.includes('lex-mesh') || key.includes('lex:mesh') || key === 'mesh';
+  });
+}
+
+function peerCount(status: MeshStatus | null, peers: MeshPeer[]): number {
+  return status?.peer_count ?? status?.total ?? peers.length;
+}
+
+function reachableCount(status: MeshStatus | null, peers: MeshPeer[]): number {
+  return status?.online ?? peers.filter((p) => p.status !== 'unreachable' && p.status !== 'disconnected').length;
+}
+
+function meshState(status: MeshStatus | null, peers: MeshPeer[], extensionLoaded: boolean | null, error: string | null): MeshState {
+  if (extensionLoaded === false || status?.extension_loaded === false) return 'not-installed';
+  if (error || status?.broker_connected === false) return 'disconnected';
+  if (status?.connected === false && peerCount(status, peers) > 0) return 'disconnected';
+  if (peerCount(status, peers) === 0) return 'solo';
+  return 'connected';
+}
+
+function meshStateLabel(state: MeshState): string {
+  switch (state) {
+    case 'not-installed':
+      return 'Extension not installed';
+    case 'solo':
+      return 'Connected · solo node';
+    case 'connected':
+      return 'Connected';
+    case 'disconnected':
+      return 'Disconnected';
+  }
 }
 
 const MeshNodeViz: FC<{ self: MeshStatus; peers: MeshPeer[] }> = ({ self, peers }) => {
@@ -129,23 +195,27 @@ export const DaemonMesh: FC<SettingsProps> = () => {
   const [status, setStatus] = useState<MeshStatus | null>(null);
   const [peers, setPeers] = useState<MeshPeer[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [meshExtensionLoaded, setMeshExtensionLoaded] = useState<boolean | null>(null);
   const [live, setLive] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const [sRes, pRes] = await Promise.all([
+      const [sRes, pRes, eRes] = await Promise.all([
         app.daemon.meshStatus(),
         app.daemon.meshPeers(),
+        app.daemon.extensions(),
       ]);
 
       if (sRes.ok && sRes.data) {
         setStatus(sRes.data as MeshStatus);
       }
       if (pRes.ok && pRes.data) {
-        const arr = Array.isArray(pRes.data) ? pRes.data : (pRes.data as { peers?: MeshPeer[] }).peers || [];
-        setPeers(arr as MeshPeer[]);
+        setPeers(normalizeList<MeshPeer>(pRes.data, 'peers'));
+      }
+      if (eRes.ok && eRes.data) {
+        setMeshExtensionLoaded(isMeshExtensionLoaded(normalizeList<ExtensionInfo>(eRes.data, 'extensions')));
       }
 
       if (!sRes.ok && !pRes.ok) {
@@ -166,6 +236,11 @@ export const DaemonMesh: FC<SettingsProps> = () => {
     return () => clearInterval(interval);
   }, [refresh, live]);
 
+  const currentState = meshState(status, peers, meshExtensionLoaded, error);
+  const isMeshReady = currentState === 'connected' || currentState === 'solo';
+  const currentPeerCount = peerCount(status, peers);
+  const currentReachableCount = reachableCount(status, peers);
+
   if (error && !status) {
     return (
       <div className="space-y-4">
@@ -178,9 +253,13 @@ export const DaemonMesh: FC<SettingsProps> = () => {
         <div className="rounded-xl border border-red-500/30 bg-red-500/5 p-4 text-xs">
           <div className="flex items-center gap-2 text-red-400">
             <AlertTriangleIcon className="h-4 w-4" />
-            <span>{error}</span>
+            <span>{meshStateLabel(currentState)}</span>
           </div>
-          <p className="mt-2 text-muted-foreground">Mesh topology requires the daemon to be running with mesh support enabled.</p>
+          <p className="mt-2 text-muted-foreground">
+            {currentState === 'not-installed'
+              ? "Add lex-mesh to your daemon's Gemfile to enable agent mesh."
+              : error}
+          </p>
         </div>
       </div>
     );
@@ -231,8 +310,8 @@ export const DaemonMesh: FC<SettingsProps> = () => {
                 <HeartPulseIcon className="h-3.5 w-3.5" />
                 Status
               </div>
-              <p className={`mt-1 text-xs font-semibold ${status?.connected ? 'text-emerald-400' : 'text-red-400'}`}>
-                {status?.connected ? 'Connected' : 'Disconnected'}
+              <p className={`mt-1 text-xs font-semibold ${isMeshReady ? 'text-emerald-400' : currentState === 'not-installed' ? 'text-amber-400' : 'text-red-400'}`}>
+                {meshStateLabel(currentState)}
               </p>
               {status?.role && <p className="text-[10px] text-muted-foreground">{status.role}</p>}
             </div>
@@ -241,9 +320,9 @@ export const DaemonMesh: FC<SettingsProps> = () => {
                 <WifiIcon className="h-3.5 w-3.5" />
                 Peers
               </div>
-              <p className="mt-1 text-xs font-semibold">{status?.peer_count ?? peers.length}</p>
+              <p className="mt-1 text-xs font-semibold">{currentPeerCount}</p>
               <p className="text-[10px] text-muted-foreground">
-                {peers.filter((p) => p.status !== 'unreachable' && p.status !== 'disconnected').length} reachable
+                {currentReachableCount} reachable
               </p>
             </div>
             <div className="rounded-xl border border-border/40 bg-card/60 p-3">
@@ -255,6 +334,12 @@ export const DaemonMesh: FC<SettingsProps> = () => {
               {status?.gossip_interval_ms && <p className="text-[10px] text-muted-foreground">gossip: {status.gossip_interval_ms}ms</p>}
             </div>
           </div>
+
+          {currentState === 'not-installed' && (
+            <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-xs text-amber-700 dark:text-amber-300">
+              Add lex-mesh to your daemon&apos;s Gemfile to enable agent mesh.
+            </div>
+          )}
 
           {/* Topology visualization */}
           {status && peers.length > 0 && (

--- a/src/components/settings/DaemonSettings.tsx
+++ b/src/components/settings/DaemonSettings.tsx
@@ -555,7 +555,10 @@ const LlmRoutingSection: FC<{ settings: DaemonSettingsData }> = ({ settings }) =
 
 const GaiaSection: FC<{ settings: DaemonSettingsData }> = ({ settings }) => {
   const gaia = (settings.gaia ?? {}) as Record<string, unknown>;
-  const mode = asString(gaia.mode, 'not configured');
+  const explicitMode = asString(gaia.mode);
+  const enabled = asBool(gaia.enabled);
+  const connected = gaia.connected;
+  const mode = explicitMode || (enabled ? (connected === false ? 'enabled (disconnected)' : 'enabled') : 'disabled');
   const channels = (gaia.channels ?? {}) as Record<string, unknown>;
   const channelNames = Object.entries(channels)
     .filter(([, cfg]) => {
@@ -564,9 +567,9 @@ const GaiaSection: FC<{ settings: DaemonSettingsData }> = ({ settings }) => {
     })
     .map(([name]) => name);
 
-  const sessionTtl = asNumber(gaia.session_ttl, 86400);
+  const sessionTtl = asNumber(dig(gaia, 'session', 'ttl'), asNumber(gaia.session_ttl, 86400));
 
-  if (mode === 'not configured' && channelNames.length === 0) return null;
+  if (Object.keys(gaia).length === 0 && channelNames.length === 0) return null;
 
   return (
     <fieldset className="rounded-lg border p-3 space-y-3">

--- a/src/components/settings/SkillSettings.tsx
+++ b/src/components/settings/SkillSettings.tsx
@@ -28,6 +28,16 @@ type SkillDetail = {
   error?: string;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function normalizeSkillList(value: unknown): SkillEntry[] {
+  if (Array.isArray(value)) return value as SkillEntry[];
+  if (isRecord(value) && Array.isArray(value.data)) return value.data as SkillEntry[];
+  return [];
+}
+
 const typeIcons: Record<string, FC<{ className?: string }>> = {
   shell: TerminalIcon,
   script: CodeIcon,
@@ -52,8 +62,8 @@ export const SkillSettings: FC<SettingsProps> = ({ config, updateConfig: _update
 
   const loadSkills = async () => {
     try {
-      const list = await app.skills.list();
-      setSkills(list);
+      const list = (await app.skills.list()) as unknown;
+      setSkills(normalizeSkillList(list));
     } catch {
       setSkills([]);
     } finally {

--- a/src/components/thread/Thread.tsx
+++ b/src/components/thread/Thread.tsx
@@ -726,6 +726,29 @@ const assistantContentComponents = {
   ToolGroup: ToolGroupWrapper,
 };
 
+type ResponseStatus = 'streaming' | 'done' | 'interrupted' | 'error';
+
+const ResponseStatusPill: FC<{ status: ResponseStatus }> = ({ status }) => {
+  const styles: Record<ResponseStatus, string> = {
+    streaming: 'border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400',
+    done: 'border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400',
+    interrupted: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300',
+    error: 'border-destructive/20 bg-destructive/10 text-destructive',
+  };
+  const labels: Record<ResponseStatus, string> = {
+    streaming: 'Streaming...',
+    done: 'Done',
+    interrupted: 'Interrupted',
+    error: 'Error',
+  };
+
+  return (
+    <span className={`mb-2 inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none ${styles[status]}`}>
+      {labels[status]}
+    </span>
+  );
+};
+
 const AssistantMessage: FC = () => {
   const message = useMessage();
   const { activeRunStartedAt } = useAssistantResponseTiming();
@@ -778,6 +801,9 @@ const AssistantMessage: FC = () => {
   const hasInterrupt = content.some((p: { type: string; source?: string }) =>
     p.type === 'text' && (p.source === 'interrupt' || p.source === 'unspoken'),
   );
+  const hasError = content.some((p: { type: string; text?: string }) =>
+    p.type === 'text' && Boolean(p.text?.includes('**Error:**')),
+  );
 
   // Extract pipeline enrichments stored as a content part
   const enrichmentsPart = content.find((p: { type: string }) => p.type === 'enrichments') as
@@ -790,6 +816,7 @@ const AssistantMessage: FC = () => {
   const badgeStartedAt = responseTiming?.startedAt ?? (isRunning ? activeRunStartedAt ?? undefined : undefined);
   const badgeFinishedAt = responseTiming?.finishedAt;
   const showResponseBadge = Boolean(badgeStartedAt);
+  const responseStatus = isRunning ? 'streaming' : hasError ? 'error' : hasInterrupt ? 'interrupted' : 'done';
 
   return (
     <MessagePrimitive.Root className="group mb-3 flex justify-start">
@@ -807,6 +834,7 @@ const AssistantMessage: FC = () => {
               />
             </div>
           )}
+          <ResponseStatusPill status={responseStatus} />
           {isEmpty ? (
             <div className="flex items-center gap-2 py-0.5 text-muted-foreground">
               <BanIcon className="h-3.5 w-3.5" />

--- a/src/providers/RuntimeProvider.tsx
+++ b/src/providers/RuntimeProvider.tsx
@@ -146,6 +146,7 @@ type MessageAccumulator = {
   messages: StoredMessage[];
   headId: string | null;
   pendingAssistantTiming?: PendingAssistantTiming | null;
+  lastProgressAt?: number;
 };
 
 function nowIso(): string {
@@ -344,6 +345,8 @@ let globalSubAgentVersion = 0; // bumped on every change to trigger re-renders
 const streamAccumulators = new Map<string, MessageAccumulator>();
 /** Conversations where the next assistant message should be forced-new (after realtime call reconnect) */
 const forceNewAssistant = new Set<string>();
+const STALE_STREAM_MS = 60_000;
+const STALE_STREAM_CHECK_MS = 15_000;
 
 function createPendingAssistantTiming(startedAt = nowIso()): PendingAssistantTiming {
   return { startedAt };
@@ -361,6 +364,10 @@ function getAccumulatorStartedAt(acc: MessageAccumulator | undefined): string | 
   if (last?.role !== 'assistant') return null;
 
   return getResponseTiming(last)?.startedAt ?? null;
+}
+
+function touchAccumulator(acc: MessageAccumulator): void {
+  acc.lastProgressAt = Date.now();
 }
 
 function withPendingAssistantTiming(message: StoredMessage, acc: MessageAccumulator): StoredMessage {
@@ -1397,13 +1404,14 @@ export function RuntimeProvider({
       if (!streamAccumulators.has(convId)) {
         if (isActiveConv) {
           const { tree: curTree, headId: curHead } = streamHandlerRef.current;
-          streamAccumulators.set(convId, { messages: [...curTree], headId: curHead });
+          streamAccumulators.set(convId, { messages: [...curTree], headId: curHead, lastProgressAt: Date.now() });
         } else {
-          streamAccumulators.set(convId, { messages: [], headId: null });
+          streamAccumulators.set(convId, { messages: [], headId: null, lastProgressAt: Date.now() });
         }
       }
 
       const acc = streamAccumulators.get(convId)!;
+      touchAccumulator(acc);
 
       if (e.type === 'tool-call' || e.type === 'tool-result' || e.type === 'tool-compaction') {
         logRuntimeToolDebug('stream-event', {
@@ -1602,6 +1610,7 @@ export function RuntimeProvider({
           }
         }
       } else if (e.type === 'error') {
+        applyError(acc, e.error ?? 'Unknown error');
         finalizeAssistantResponse(acc);
         if (persistTimerRef.current) { clearTimeout(persistTimerRef.current); persistTimerRef.current = null; }
         streamAccumulators.delete(convId);
@@ -1661,6 +1670,51 @@ export function RuntimeProvider({
     });
     return unsubscribe;
   }, [bumpSubAgentVersion]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+
+      for (const [convId, acc] of streamAccumulators.entries()) {
+        const lastProgressAt = acc.lastProgressAt ?? now;
+        if (now - lastProgressAt < STALE_STREAM_MS) continue;
+
+        applyError(acc, 'Stream stopped without a completion event.');
+        finalizeAssistantResponse(acc);
+        streamAccumulators.delete(convId);
+
+        const isActiveConv = convId === activeIdRef.current;
+        persistConversation(convId, acc.messages, acc.headId, {
+          runStatus: 'idle',
+          lastAssistantUpdateAt: nowIso(),
+          hasUnread: !isActiveConv,
+        });
+
+        if (isActiveConv) {
+          setIsRunning(false);
+          setTree([...acc.messages]);
+          setHeadId(acc.headId);
+        }
+      }
+
+      void (async () => {
+        const conversations = await app.conversations.list() as ConversationRecord[];
+        const staleBefore = Date.now() - STALE_STREAM_MS;
+        for (const conv of conversations) {
+          if (conv.runStatus !== 'running' || streamAccumulators.has(conv.id)) continue;
+          const lastActivity = Date.parse(conv.lastAssistantUpdateAt ?? conv.updatedAt);
+          if (Number.isNaN(lastActivity) || lastActivity > staleBefore) continue;
+          const { tree: persistedTree, headId: persistedHead } = ensureTree(conv);
+          await persistConversation(conv.id, persistedTree, persistedHead, { runStatus: 'idle' });
+          if (conv.id === activeIdRef.current) setIsRunning(false);
+        }
+      })().catch((err) => {
+        console.error('[Runtime] Failed stale stream recovery:', err);
+      });
+    }, STALE_STREAM_CHECK_MS);
+
+    return () => clearInterval(interval);
+  }, []);
 
   // Listen for proactive GAIA messages and inject into the active conversation
   useEffect(() => {
@@ -1735,7 +1789,7 @@ export function RuntimeProvider({
     setHeadId(newHead);
     setIsRunning(true);
 
-    streamAccumulators.set(convId, { messages: [...newTree], headId: newHead, pendingAssistantTiming });
+    streamAccumulators.set(convId, { messages: [...newTree], headId: newHead, pendingAssistantTiming, lastProgressAt: Date.now() });
     const branch = getActiveBranch(newTree, newHead);
     await persistConversation(convId, newTree, newHead, { runStatus: 'running' });
     void maybeGenerateTitle(convId, branch);
@@ -1768,6 +1822,7 @@ export function RuntimeProvider({
       messages: newTree,
       headId: actualParent,
       pendingAssistantTiming: createPendingAssistantTiming(),
+      lastProgressAt: Date.now(),
     });
     const branch = getActiveBranch(newTree, actualParent);
     persistConversation(convId, newTree, actualParent, { runStatus: 'running' });


### PR DESCRIPTION
## Summary
- Fix GAIA settings session count and daemon settings GAIA mode/TTL rendering
- Fix Events and Skills settings tabs to tolerate daemon response shape changes
- Clarify Mesh installed/solo/disconnected states
- Add chat stream completion status and stale-stream recovery
- Fix dashboard worker health counts from lifecycle_state

## Issues
Fixes #60
Fixes #61
Fixes #58
Fixes #57
Fixes #56
Fixes #55
Fixes #54

## Verification
- pnpm type-check
- pnpm lint (passes with existing warnings only)
- pnpm build