### PR TITLE
Handle legion-llm thinking delta SSE events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.23] - 2026-04-28
+
+### Fixed
+- Daemon SSE clients now recognize `thinking-delta` events from legion-llm reasoning streams without appending reasoning text to assistant chat responses.
+
 ## [1.1.22] - 2026-04-27
 
 ### Fixed

--- a/electron/agent/app-runtime.ts
+++ b/electron/agent/app-runtime.ts
@@ -432,6 +432,11 @@ async function* consumeDaemonSSE(
         return text ? [{ conversationId, type: 'text-delta', text }] : [];
       }
 
+      if (eventName === 'thinking-delta' || eventName === 'thinking_delta') {
+        const text = normalizeAssistantText(payload.text ?? payload.delta ?? payload.thinking);
+        return text ? [{ conversationId, type: 'thinking-delta', text }] : [];
+      }
+
       if (eventName === 'tool-call' || eventName === 'tool_call') {
         return [{
           conversationId,

--- a/electron/agent/daemon-chat-client.ts
+++ b/electron/agent/daemon-chat-client.ts
@@ -104,18 +104,28 @@ export class DaemonChatClient {
     let buffer = '';
     let streamDone = false;
     let streamError: string | undefined;
+    let currentEventName = '';
 
     const processLine = (line: string): void => {
       const trimmed = line.replace(/\r$/, '');
-      if (!trimmed || trimmed.startsWith(':') || trimmed.startsWith('event:')) return;
+      if (!trimmed || trimmed.startsWith(':')) return;
+      if (trimmed.startsWith('event:')) {
+        currentEventName = trimmed.slice(6).trim();
+        return;
+      }
       if (!trimmed.startsWith('data:')) return;
       const raw = trimmed.slice(5).trimStart();
       if (!raw || raw === '[DONE]') {
         streamDone = true;
+        currentEventName = '';
         return;
       }
       try {
         const parsed = JSON.parse(raw) as { text?: string; delta?: string; done?: boolean; error?: string };
+        const eventName = currentEventName;
+        currentEventName = '';
+        if (eventName === 'thinking-delta' || eventName === 'thinking_delta') return;
+
         if (parsed.error) {
           streamError = parsed.error;
           streamDone = true;
@@ -131,6 +141,10 @@ export class DaemonChatClient {
           onChunk(delta);
         }
       } catch {
+        const eventName = currentEventName;
+        currentEventName = '';
+        if (eventName === 'thinking-delta' || eventName === 'thinking_delta') return;
+
         // Non-JSON data line — forward as raw text delta
         fullText += raw;
         onChunk(raw);

--- a/electron/agent/mastra-agent.ts
+++ b/electron/agent/mastra-agent.ts
@@ -9,7 +9,7 @@ export type { ReasoningEffort } from './model-catalog.js';
 
 export type StreamEvent = {
   conversationId: string;
-  type: 'text-delta' | 'observer-message' | 'tool-call' | 'tool-result' | 'tool-error' | 'tool-progress' | 'tool-compaction' | 'error' | 'done' | 'compaction' | 'context-usage' | 'model-fallback' | 'enrichment';
+  type: 'text-delta' | 'thinking-delta' | 'observer-message' | 'tool-call' | 'tool-result' | 'tool-error' | 'tool-progress' | 'tool-compaction' | 'error' | 'done' | 'compaction' | 'context-usage' | 'model-fallback' | 'enrichment';
   text?: string;
   toolCallId?: string;
   toolName?: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/src/providers/RuntimeProvider.tsx
+++ b/src/providers/RuntimeProvider.tsx
@@ -1481,6 +1481,8 @@ export function RuntimeProvider({
           }
         }
         applyTextDelta(acc, e.text ?? '');
+      } else if (e.type === 'thinking-delta') {
+        return;
       } else if (e.type === 'realtime-user-transcript') {
         // Realtime audio: create/update a user message for spoken text
         const itemId = (e as { itemId?: string }).itemId ?? msgId();


### PR DESCRIPTION
## Summary
- recognize legion-llm `thinking-delta` / `thinking_delta` SSE events in daemon streaming
- keep reasoning deltas out of assistant message text while preserving typed stream handling
- update legacy daemon chat SSE parsing so event-named thinking chunks are ignored instead of appended
- bump Interlink to 1.1.23

## Related
- Follow-up from LegionIO/legion-llm#96 triage
- Complements LegionIO/legion-llm#102 routing uplift

## Verification
- `pnpm type-check`
- `pnpm lint` (passes with existing warnings only)