### PR TITLE
[codex] tolerate daemon LLM provider inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.25] - 2026-04-28
+
+### Fixed
+- LLM router settings now refresh live offering sources through the daemon provider inventory endpoint instead of the generic capabilities endpoint.
+
 ## [1.1.24] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.24] - 2026-04-28
+
+### Fixed
+- Daemon LLM model discovery now accepts both legacy provider responses and native inventory responses from the routing redesign, and settings now uses router/offering wording while loading older mode values.
+
 ## [1.1.23] - 2026-04-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This starts the Electron app with the renderer and main process in watch mode.
 
 ```bash
 pnpm lint
+pnpm test
 pnpm type-check
 pnpm build
 pnpm preview
@@ -98,7 +99,7 @@ The app maintains a model catalog plus provider settings. The current implementa
 - Google
 - Amazon Bedrock
 
-Users can choose a default model and switch models per conversation.
+Users can choose a default model and switch models per conversation. When a local daemon is reachable, model discovery can also use daemon model and provider inventory before falling back to the local catalog.
 
 ### Tools
 

--- a/electron/config/schema.test.ts
+++ b/electron/config/schema.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { providerLayerConfigSchema } from './schema.js';
+
+test('providerLayerConfigSchema exposes daemon router fallback while accepting legacy RubyLLM key', () => {
+  assert.equal(providerLayerConfigSchema.parse({}).fallbackToDaemonRouter, true);
+  assert.equal(
+    providerLayerConfigSchema.parse({ fallbackToDaemonRouter: false }).fallbackToDaemonRouter,
+    false,
+  );
+  const legacy = providerLayerConfigSchema.parse({ mode: 'ruby_llm', fallbackToRubyLlm: false });
+  assert.equal(legacy.mode, 'daemon_router');
+  assert.equal(legacy.fallbackToDaemonRouter, false);
+  assert.equal('fallbackToRubyLlm' in legacy, false);
+});

--- a/electron/config/schema.ts
+++ b/electron/config/schema.ts
@@ -412,7 +412,7 @@ const tokenBudgetConfigSchema = z.object({
 });
 
 const providerLayerConfigSchema = z.object({
-  mode: z.enum(['ruby_llm', 'native', 'auto']).default('ruby_llm'),
+  mode: z.enum(['daemon_router', 'native_offerings', 'auto', 'ruby_llm', 'native']).default('daemon_router'),
   nativeProviders: z.array(z.string()).default(['claude', 'bedrock']),
   fallbackToRubyLlm: z.boolean().default(true),
 });

--- a/electron/config/schema.ts
+++ b/electron/config/schema.ts
@@ -411,11 +411,18 @@ const tokenBudgetConfigSchema = z.object({
   dailyMaxTokens: z.number().positive().nullable().default(null),
 });
 
-const providerLayerConfigSchema = z.object({
+export const providerLayerConfigSchema = z.object({
   mode: z.enum(['daemon_router', 'native_offerings', 'auto', 'ruby_llm', 'native']).default('daemon_router'),
   nativeProviders: z.array(z.string()).default(['claude', 'bedrock']),
-  fallbackToRubyLlm: z.boolean().default(true),
-});
+  fallbackToDaemonRouter: z.boolean().optional(),
+  fallbackToRubyLlm: z.boolean().optional(),
+}).transform((config) => ({
+  mode: config.mode === 'native'
+    ? 'native_offerings' as const
+    : config.mode === 'ruby_llm' ? 'daemon_router' as const : config.mode,
+  nativeProviders: config.nativeProviders,
+  fallbackToDaemonRouter: config.fallbackToDaemonRouter ?? config.fallbackToRubyLlm ?? true,
+}));
 
 const tierRoutingConfigSchema = z.object({
   enabled: z.boolean().default(true),

--- a/electron/ipc/agent.ts
+++ b/electron/ipc/agent.ts
@@ -11,6 +11,7 @@ import { daemonGet } from '../lib/daemon-client.js';
 import type { ToolDefinition } from '../tools/types.js';
 import { ensureSafeToolDefinitions } from '../tools/naming.js';
 import { sendSubAgentFollowUp, stopSubAgent, getActiveSubAgentIds } from '../tools/sub-agent.js';
+import { normalizeProviderModelObjects, type OpenAIModelObject } from './llm-provider-models.js';
 
 type DaemonModelEntry = {
   key: string;
@@ -24,11 +25,6 @@ type DaemonModelEntry = {
 type DaemonModelCatalog = {
   models: DaemonModelEntry[];
   defaultKey: string | null;
-};
-
-type OpenAIModelObject = { id: string; owned_by?: string };
-type ProvidersResponse = {
-  providers?: Array<{ name: string; default_model?: string }>;
 };
 
 async function fetchDaemonModels(
@@ -48,12 +44,9 @@ async function fetchDaemonModels(
   }
 
   if (modelList.length === 0) {
-    const providersResult = await daemonGet<ProvidersResponse>(config, appHome, '/api/llm/providers');
+    const providersResult = await daemonGet<unknown>(config, appHome, '/api/llm/providers');
     if (providersResult.ok && providersResult.data) {
-      const providers = providersResult.data.providers ?? [];
-      modelList = providers
-        .filter((p) => p.default_model)
-        .map((p) => ({ id: p.default_model!, owned_by: p.name }));
+      modelList = normalizeProviderModelObjects(providersResult.data);
     }
   }
 

--- a/electron/ipc/daemon-api.ts
+++ b/electron/ipc/daemon-api.ts
@@ -436,9 +436,6 @@ export function registerDaemonApiHandlers(
   ipcMain.handle('daemon:llm-providers', async () =>
     daemonGet(cfg(), appHome, '/api/llm/providers'));
 
-  ipcMain.handle('daemon:llm-provider-layer', async () =>
-    daemonGet(cfg(), appHome, '/api/llm/provider_layer'));
-
   // ── Context Curation (legion-llm v0.6.0) ──
   ipcMain.handle('daemon:llm-context-curation-status', async () =>
     daemonGet(cfg(), appHome, '/api/llm/context_curation/status'));

--- a/electron/ipc/llm-provider-models.test.ts
+++ b/electron/ipc/llm-provider-models.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { normalizeProviderModelObjects } from './llm-provider-models.js';
+
+describe('normalizeProviderModelObjects', () => {
+  it('keeps compatibility with name/default_model provider responses', () => {
+    assert.deepEqual(
+      normalizeProviderModelObjects({
+        providers: [
+          { name: 'openai', default_model: 'gpt-4.1' },
+          { name: 'anthropic' },
+        ],
+      }),
+      [{ id: 'gpt-4.1', owned_by: 'openai' }],
+    );
+  });
+
+  it('reads provider/models inventory responses without duplicating defaults', () => {
+    assert.deepEqual(
+      normalizeProviderModelObjects({
+        providers: [
+          {
+            provider: 'anthropic',
+            circuit: 'closed',
+            adjustment: 0,
+            healthy: true,
+            default_model: 'claude-sonnet-4-5',
+            models: ['claude-sonnet-4-5', 'claude-haiku-4-5'],
+            offerings: [],
+            types: ['chat'],
+            instances: [],
+          },
+          {
+            provider: 'bedrock',
+            models: [
+              { id: 'us.anthropic.claude-sonnet-4-5-v1:0' },
+              { model: 'amazon.nova-pro-v1:0' },
+            ],
+          },
+        ],
+      }),
+      [
+        { id: 'claude-sonnet-4-5', owned_by: 'anthropic' },
+        { id: 'claude-haiku-4-5', owned_by: 'anthropic' },
+        { id: 'us.anthropic.claude-sonnet-4-5-v1:0', owned_by: 'bedrock' },
+        { id: 'amazon.nova-pro-v1:0', owned_by: 'bedrock' },
+      ],
+    );
+  });
+
+  it('ignores malformed entries and still returns usable model identifiers', () => {
+    assert.deepEqual(
+      normalizeProviderModelObjects({
+        providers: [
+          null,
+          { provider: '', default_model: '' },
+          { circuit: 'open', models: [null, {}, { name: 'usable-model' }] },
+        ],
+      }),
+      [{ id: 'usable-model' }],
+    );
+  });
+});

--- a/electron/ipc/llm-provider-models.test.ts
+++ b/electron/ipc/llm-provider-models.test.ts
@@ -48,6 +48,26 @@ describe('normalizeProviderModelObjects', () => {
     );
   });
 
+  it('reads LegionIO provider-health inventory responses', () => {
+    assert.deepEqual(
+      normalizeProviderModelObjects({
+        providers: [
+          {
+            provider: 'anthropic',
+            circuit: 'closed',
+            adjustment: 0,
+            healthy: true,
+            offerings: 1,
+            models: ['claude-sonnet-4-6'],
+            types: ['inference'],
+            instances: ['bedrock-east-2'],
+          },
+        ],
+      }),
+      [{ id: 'claude-sonnet-4-6', owned_by: 'anthropic' }],
+    );
+  });
+
   it('ignores malformed entries and still returns usable model identifiers', () => {
     assert.deepEqual(
       normalizeProviderModelObjects({

--- a/electron/ipc/llm-provider-models.ts
+++ b/electron/ipc/llm-provider-models.ts
@@ -1,0 +1,61 @@
+export type OpenAIModelObject = { id: string; owned_by?: string };
+
+type ProviderInventory = {
+  providers?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return null;
+}
+
+function modelId(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() || null;
+  if (!isRecord(value)) return null;
+  return stringField(value, ['id', 'model', 'name', 'key', 'model_id']);
+}
+
+function providerEntries(response: unknown): unknown[] {
+  if (Array.isArray(response)) return response;
+  if (!isRecord(response)) return [];
+
+  const providers = (response as ProviderInventory).providers;
+  return Array.isArray(providers) ? providers : [];
+}
+
+export function normalizeProviderModelObjects(response: unknown): OpenAIModelObject[] {
+  const models: OpenAIModelObject[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of providerEntries(response)) {
+    if (!isRecord(entry)) continue;
+
+    const providerName = stringField(entry, ['provider', 'name']) ?? undefined;
+    const ids = new Set<string>();
+    const defaultModel = stringField(entry, ['default_model', 'defaultModel']);
+    if (defaultModel) ids.add(defaultModel);
+
+    const rawModels = entry.models;
+    if (Array.isArray(rawModels)) {
+      for (const rawModel of rawModels) {
+        const id = modelId(rawModel);
+        if (id) ids.add(id);
+      }
+    }
+
+    for (const id of ids) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      models.push(providerName ? { id, owned_by: providerName } : { id });
+    }
+  }
+
+  return models;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -157,6 +157,7 @@ const appAPI = {
     absorberDispatch: (input: string, scope?: string) => ipcRenderer.invoke('daemon:absorber-dispatch', input, scope),
     absorberJob: (jobId: string) => ipcRenderer.invoke('daemon:absorber-job', jobId),
     llmModels: () => ipcRenderer.invoke('daemon:llm-models'),
+    llmProviders: () => ipcRenderer.invoke('daemon:llm-providers'),
     health: () => ipcRenderer.invoke('daemon:health'),
     ready: () => ipcRenderer.invoke('daemon:ready'),
     metrics: () => ipcRenderer.invoke('daemon:metrics'),

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "compile:swift": "bash scripts/compile-swift-helper.sh",
     "generate:builder": "tsx scripts/generate-builder-config.ts",
     "build:mac": "pnpm compile:swift && pnpm build && pnpm generate:builder && electron-builder --mac --config",
+    "test": "node --import tsx --test \"electron/**/*.test.ts\"",
     "lint": "eslint .",
     "type-check": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legion-interlink",
   "productName": "Legion Interlink",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "Legion Interlink - Local AI Assistant",
   "main": "./out/main/index.js",
   "type": "module",

--- a/src/components/settings/DaemonLlmSettings.tsx
+++ b/src/components/settings/DaemonLlmSettings.tsx
@@ -246,7 +246,7 @@ const ProviderLayerSection: FC<{
   const fetchProviders = useCallback(async () => {
     setLoadingProviders(true);
     try {
-      const res = await app.daemon.capabilities();
+      const res = await app.daemon.llmProviders();
       if (res.ok && res.data) {
         const data = res.data as Record<string, unknown>;
         const list = Array.isArray(data.providers)

--- a/src/components/settings/DaemonLlmSettings.tsx
+++ b/src/components/settings/DaemonLlmSettings.tsx
@@ -61,7 +61,7 @@ type DaemonLlmConfig = {
     dailyMaxTokens?: number | null;
   };
   providerLayer?: {
-    mode?: 'ruby_llm' | 'native' | 'auto';
+    mode?: 'daemon_router' | 'native_offerings' | 'auto' | 'ruby_llm' | 'native';
     nativeProviders?: string[];
     fallbackToRubyLlm?: boolean;
   };
@@ -74,6 +74,8 @@ type DaemonLlmConfig = {
     pipelineEnabled?: boolean;
   };
 };
+
+type ProviderRoutingMode = NonNullable<NonNullable<DaemonLlmConfig['providerLayer']>['mode']>;
 
 // ── Live status types ─────────────────────────────────────────────────────────
 
@@ -111,6 +113,50 @@ function numOrNull(raw: string): number | null {
   if (trimmed === '') return null;
   const n = Number(trimmed);
   return isNaN(n) ? null : n;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : null;
+}
+
+function providerName(value: Record<string, unknown>): string | null {
+  for (const key of ['provider', 'name']) {
+    const raw = value[key];
+    if (typeof raw === 'string' && raw.trim() !== '') return raw.trim();
+  }
+  return null;
+}
+
+function modelCount(value: Record<string, unknown>): number | undefined {
+  const raw = value.models;
+  if (Array.isArray(raw)) return raw.length;
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  return undefined;
+}
+
+function normalizeProviderInfo(value: unknown): ProviderInfo | null {
+  const item = record(value);
+  if (!item) return null;
+
+  const name = providerName(item);
+  if (!name) return null;
+
+  const enabled = typeof item.enabled === 'boolean'
+    ? item.enabled
+    : typeof item.healthy === 'boolean' ? item.healthy : undefined;
+  const models = modelCount(item);
+
+  return {
+    name,
+    ...(enabled == null ? {} : { enabled }),
+    ...(models == null ? {} : { models }),
+  };
+}
+
+function normalizeRoutingMode(mode: ProviderRoutingMode | undefined): 'daemon_router' | 'native_offerings' | 'auto' {
+  if (mode === 'native' || mode === 'native_offerings') return 'native_offerings';
+  if (mode === 'auto') return 'auto';
+  return 'daemon_router';
 }
 
 // ── Collapsible section wrapper ───────────────────────────────────────────────
@@ -181,14 +227,14 @@ const NullableNumberInput: FC<{
   );
 };
 
-// ── Provider Layer section ────────────────────────────────────────────────────
+// ── LLM routing section ───────────────────────────────────────────────────────
 
 const ProviderLayerSection: FC<{
   daemonLlm: DaemonLlmConfig;
   updateConfig: (path: string, value: unknown) => Promise<void>;
 }> = ({ daemonLlm, updateConfig }) => {
   const pl = daemonLlm.providerLayer ?? {};
-  const mode = pl.mode ?? 'ruby_llm';
+  const mode = normalizeRoutingMode(pl.mode);
   const nativeProviders = pl.nativeProviders ?? ['claude', 'bedrock'];
   const fallback = pl.fallbackToRubyLlm ?? true;
 
@@ -202,7 +248,9 @@ const ProviderLayerSection: FC<{
       const res = await app.daemon.capabilities();
       if (res.ok && res.data) {
         const data = res.data as Record<string, unknown>;
-        const list = Array.isArray(data.providers) ? data.providers as ProviderInfo[] : [];
+        const list = Array.isArray(data.providers)
+          ? data.providers.map(normalizeProviderInfo).filter((p): p is ProviderInfo => p != null)
+          : [];
         setProviders(list);
       }
     } catch {
@@ -226,32 +274,32 @@ const ProviderLayerSection: FC<{
   };
 
   return (
-    <Section icon={ServerIcon} title="Provider Layer" description="How the daemon routes LLM calls" defaultOpen>
+    <Section icon={ServerIcon} title="LLM Router" description="How the daemon chooses model offerings" defaultOpen>
       <div>
-        <label className="text-[10px] text-muted-foreground block mb-0.5">Mode</label>
+        <label className="text-[10px] text-muted-foreground block mb-0.5">Routing Mode</label>
         <select
           className={settingsSelectClass}
           value={mode}
           onChange={(e) => updateConfig('appConfig.daemonLlm.providerLayer.mode', e.target.value)}
         >
-          <option value="ruby_llm">ruby_llm (default Ruby LLM provider)</option>
-          <option value="native">native (Electron-side providers only)</option>
-          <option value="auto">auto (prefer native, fall back to ruby_llm)</option>
+          <option value="daemon_router">Daemon router (default)</option>
+          <option value="native_offerings">Native offerings only</option>
+          <option value="auto">Automatic fallback routing</option>
         </select>
         <p className="text-[10px] text-muted-foreground/70 mt-0.5">
-          Controls whether the daemon uses its built-in ruby_llm layer, native Electron providers, or both.
+          Controls whether requests use daemon-managed routing, local native offerings, or automatic fallback.
         </p>
       </div>
 
       <Toggle
-        label="Fall back to ruby_llm if native provider fails"
+        label="Fall back to daemon router if a native offering fails"
         checked={fallback}
         onChange={(v) => updateConfig('appConfig.daemonLlm.providerLayer.fallbackToRubyLlm', v)}
       />
 
       <div>
         <div className="flex items-center justify-between mb-1">
-          <label className="text-[10px] text-muted-foreground">Native Providers</label>
+          <label className="text-[10px] text-muted-foreground">Native Offerings</label>
           <button
             type="button"
             onClick={() => void fetchProviders()}
@@ -290,7 +338,7 @@ const ProviderLayerSection: FC<{
           <input
             type="text"
             className="flex-1 rounded-xl border border-border/70 bg-card/80 px-3 py-1.5 text-xs outline-none font-mono"
-            placeholder="provider name (e.g. openai)"
+            placeholder="offering source (e.g. openai)"
             value={newProvider}
             onChange={(e) => setNewProvider(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') addProvider(); }}
@@ -307,7 +355,7 @@ const ProviderLayerSection: FC<{
 
         {providers.length > 0 && (
           <p className="text-[10px] text-muted-foreground/60 mt-1">
-            {providers.length} provider{providers.length !== 1 ? 's' : ''} registered in daemon
+            {providers.length} offering source{providers.length !== 1 ? 's' : ''} registered in daemon
           </p>
         )}
       </div>

--- a/src/components/settings/DaemonLlmSettings.tsx
+++ b/src/components/settings/DaemonLlmSettings.tsx
@@ -63,6 +63,7 @@ type DaemonLlmConfig = {
   providerLayer?: {
     mode?: 'daemon_router' | 'native_offerings' | 'auto' | 'ruby_llm' | 'native';
     nativeProviders?: string[];
+    fallbackToDaemonRouter?: boolean;
     fallbackToRubyLlm?: boolean;
   };
   tierRouting?: {
@@ -236,7 +237,7 @@ const ProviderLayerSection: FC<{
   const pl = daemonLlm.providerLayer ?? {};
   const mode = normalizeRoutingMode(pl.mode);
   const nativeProviders = pl.nativeProviders ?? ['claude', 'bedrock'];
-  const fallback = pl.fallbackToRubyLlm ?? true;
+  const fallback = pl.fallbackToDaemonRouter ?? pl.fallbackToRubyLlm ?? true;
 
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [loadingProviders, setLoadingProviders] = useState(false);
@@ -294,7 +295,7 @@ const ProviderLayerSection: FC<{
       <Toggle
         label="Fall back to daemon router if a native offering fails"
         checked={fallback}
-        onChange={(v) => updateConfig('appConfig.daemonLlm.providerLayer.fallbackToRubyLlm', v)}
+        onChange={(v) => updateConfig('appConfig.daemonLlm.providerLayer.fallbackToDaemonRouter', v)}
       />
 
       <div>

--- a/src/lib/ipc-client.ts
+++ b/src/lib/ipc-client.ts
@@ -128,6 +128,7 @@ type AppAPI = {
     absorberDispatch: (input: string, scope?: string) => Promise<DaemonResult>;
     absorberJob: (jobId: string) => Promise<DaemonResult>;
     llmModels: () => Promise<DaemonResult>;
+    llmProviders: () => Promise<DaemonResult>;
     health: () => Promise<DaemonResult>;
     ready: () => Promise<DaemonResult>;
     metrics: () => Promise<DaemonResult>;


### PR DESCRIPTION
## Summary

Updates Interlink's daemon LLM discovery path to tolerate both the legacy `/api/llm/providers` response shape and the newer native inventory shape from the LLM routing redesign. Also removes stale downstream assumptions from the settings/provider-router uplift scan.

## Changes

- Added a focused provider inventory normalizer for `/api/llm/providers` responses.
- Preserved legacy `{ name, default_model }` compatibility while supporting `{ provider, models }` inventory entries and object-shaped model entries.
- Updated daemon model fallback discovery to use the normalizer and avoid crashing on missing or malformed fields.
- Removed the dead `daemon:llm-provider-layer` IPC bridge to unsupported `/api/llm/provider_layer`; current Legion LLM exposes `/api/llm/providers` and `/api/llm/providers/:name`.
- Reframed settings UI copy around LLM router/native offerings language while keeping old `ruby_llm`/`native` mode values loadable.
- Added neutral `fallbackToDaemonRouter` config output/write path while still accepting legacy `fallbackToRubyLlm` input.
- Wired the settings panel live offering refresh through the daemon provider inventory IPC bridge instead of the generic capabilities endpoint.
- Updated README command/model-discovery notes and bumped release metadata to 1.1.25.
- Added a lightweight Node test command and focused coverage for old/new/malformed provider response shapes, LegionIO provider-health inventory, and provider-router config compatibility.

## Verification

- `pnpm test`
- `pnpm type-check`
- `pnpm lint` (passes with existing warning-only offenses)
- `pnpm build`
- GitHub PR checks on `46a7804` are passing

## Notes

`pnpm lint` reports existing unused-variable warnings in `electron/ipc/agent.ts`, `src/components/settings/SettingsPanel.tsx`, and the checked-in `.worktrees/perf-fixes` copy. `pnpm build` reports the existing Vite dynamic/static import warning for `electron/computer-use/permissions.ts`.

GitHub reported an unrelated default-branch Dependabot notice during push: 1 moderate vulnerability.

This should stay draft until the related LLM/Core uplift dependencies are ready: `LegionIO/legion-llm#102` and `LegionIO/LegionIO#175`.