### PR TITLE
docs: add CHANGELOG entry for v2.0.0 Swift menu bar rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.0.0] - 2026-05-04
+
+### Changed
+- **BREAKING**: Replaced the Electron desktop chat client with a native Swift macOS menu bar app. Legion Interlink is no longer a desktop chat UI — it is a menu bar utility that bootstraps, monitors, and controls the LegionIO daemon stack (legionio, redis, memcached, ollama).
+- Minimum macOS version raised from 10.13 to 13 (Ventura).
+- App size reduced from ~454MB (Electron + Chromium + Node) to ~592KB (native Swift binary).
+
+### Added
+- Menu bar item with Legion icon and live status badge reflecting daemon health.
+- Native dashboard window with five tabs: Services (default), Logs, Extensions, Workers, Settings.
+- Service cards with start/stop controls, daemon component readiness indicators, and start-all / stop-all actions.
+- Live daemon log viewer with auto-scroll toggle and clear.
+- Search filtering across Extensions, Workers, and Settings tabs.
+- First-launch onboarding that auto-starts services and installs the agentic extension pack when `~/.legionio/.packs/agentic` is absent.
+- Health polling that updates service status within 5 seconds of state changes.
+- Launch-at-login toggle.
+- Universal binary builds (arm64 + x86_64) with code signing, notarization, and Homebrew Cask updates wired into release CI.
+
+### Removed
+- All Electron, React, TypeScript, and Node.js code (~70k lines, 245+ files), including the chat thread, sub-agent views, MCP integration UI, skills UI, memory/compaction settings UI, and trigger workflow components.
+- All npm dependencies (52 known vulnerabilities eliminated).
+
+### Migration
+Chat and AI assistant functionality has moved to **Kai** (`brew install --cask legionio/tap/kai`), which connects to the same legionio daemon stack via the `kai-plugin-legion` plugin. Legion Interlink now exists solely to manage the daemon services.
+
 ## [1.1.6] - 2026-04-22
 
 ### Changed


### PR DESCRIPTION
## Summary

- Adds a `[2.0.0]` entry to `CHANGELOG.md` documenting the Electron-to-Swift menu bar rewrite from #52
- Unblocks the `Changelog Check` CI job on #52, which has been failing since 2026-04-23

## Why

#52 has been red on CI for ~11 days, but the only failing job is `Changelog Check`:

```
ERROR: CHANGELOG.md was not updated. Add an entry for your changes.
Process completed with exit code 1.
```

`Version Bump Check` and `Build & Verify` both pass — the Swift code itself is fine. The PR is just missing a changelog entry, which the workflow gates on (`.github/workflows/release.yml`).

## What

Adds a `[2.0.0] - 2026-05-04` section at the top of `CHANGELOG.md` matching the existing Keep-a-Changelog style. The entry summarizes the Electron → Swift transition: BREAKING change note, size/min-OS deltas, the new menu bar + dashboard features, and the removal of the Electron stack. It also points users to Kai for the chat experience.

## Merge target

Targets `feature/swift-menu-bar` (the #52 branch), not `main`. Once this lands on the feature branch, #52 should go green and be ready for merge.

## Test plan

- [ ] CI on this PR passes (sanity check the changelog entry diff)
- [ ] After merge into `feature/swift-menu-bar`, re-run #52's checks — `Changelog Check` should turn green